### PR TITLE
Correções para funcionar como uma biblioteca

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,12 +1,14 @@
-import Vue from 'vue'
-import StabContainer from './StabContainer'
+import stabContainer from './StabContainer';
+
+export const StabContainer = stabContainer;
 
 const components = {
     StabContainer
+};
+
+export default {
+    install(Vue) {
+        Object.keys(components)
+            .forEach(name => Vue.component(name, components[name]))
+    }
 }
-
-Object.keys(components).forEach(name => {
-    Vue.component(name, components[name])
-})
-
-export default components


### PR DESCRIPTION
Vi seu post no grupo de Vue.js no facebook e decidi dar uma mãozinha.

Para poder funcionar o seu: `import { StabContainer } from '@estudiorilo/stab'` você deve exportar o `StabContainer` como um "atributo" do seu módulo/pacote e não como um atributo do valor default do módulo/pacote.

O que você fez resulta nisso: `modulo.default.StabContainer`, mas o que você deseja é `modulo.StabContainer`. Devido a sintaxe do ES6 e com a feature de desestruturação de objeto o que você fez parece válido como sintaxe mas estruturalmente é bem diferente.

Eu fiz outra alteração no que se refere ao auto registro dos componentes. Legal a idéia mas o ideal, seguindo o padrão de libs, é usar a interface de plugin. 
Que nada mais é que fornecer um método `install`, no `export default`, que recebe como primeiro parâmetro o `Vue` do projeto que esta usando sua lib. 
Então criei um método `install` para o `export default` assim quem for usar sua lib precisará fazer `Vue.use` para registrar seus componentes, exemplo:
```
import Vue from 'vue';
import StabPlugin from `@estudiorilo/stab`;

Vue.use(StabPlugin);
```

Note que eu removi o `import Vue from 'vue'` do arquivo. Para uma lib isso é uma má prática, sorte que o CLI do Vue ja trata isso pra gente. Porque o ideal para uma lib é usar o Vue do projeto que esta importando a lib, ao fazer o import do Vue no código da sua lib você esta empacotando o Vue que você usou para criar o projeto na lib, tornando ela pesada pois quem importar seu projeto estará importando todo o Vue que você usou e não surtirá efeito no projeto dele pois o Vue que você registrou os componentes é o Vue da lib. Mas o CLI ja cuida disso forçando que todo `import Vue from 'vue'` utilize o Vue de quem usa a lib e não empacota o Vue que você usou para desenvolver no bundle.